### PR TITLE
#24 exporting rust types (part 1)

### DIFF
--- a/nmm/lib/index.js
+++ b/nmm/lib/index.js
@@ -1,3 +1,9 @@
 var addon = require('../native');
+const { Manager } = addon;
 
-console.log(addon.hello());
+const man = new Manager();
+console.log(Manager);
+console.log(man);
+var board = man.get_board();
+console.log(board);
+console.log("Board at G7: " + board["G7"]);

--- a/nmm/native/base/src/lib.rs
+++ b/nmm/native/base/src/lib.rs
@@ -88,7 +88,7 @@ pub enum Action {
 
 // TODO: Make top level GameResult type that wraps GameState and custom GameErr types?
 #[derive(Debug, Clone)]
-struct GameState {
+pub struct GameState {
     handle: Handle,
     trigger: Trigger,
     board: Board,
@@ -220,36 +220,108 @@ impl Default for Board {
         //       `new_from_n(n)` and `default()` from having such noisy declarations.
         let valid_positions: HashMap<Coord, PositionStatus> = [
             // A => 1, 4, 7
-            (Coord::new(XCoord::A, YCoord::One), (false, None)),
-            (Coord::new(XCoord::A, YCoord::Four), (false, None)),
-            (Coord::new(XCoord::A, YCoord::Seven), (false, None)),
+            (
+                Coord::new(XCoord::A, YCoord::One),
+                PositionStatus::default(),
+            ),
+            (
+                Coord::new(XCoord::A, YCoord::Four),
+                PositionStatus::default(),
+            ),
+            (
+                Coord::new(XCoord::A, YCoord::Seven),
+                PositionStatus::default(),
+            ),
             // B => 2, 4, 6
-            (Coord::new(XCoord::B, YCoord::Two), (false, None)),
-            (Coord::new(XCoord::B, YCoord::Four), (false, None)),
-            (Coord::new(XCoord::B, YCoord::Six), (false, None)),
+            (
+                Coord::new(XCoord::B, YCoord::Two),
+                PositionStatus::default(),
+            ),
+            (
+                Coord::new(XCoord::B, YCoord::Four),
+                PositionStatus::default(),
+            ),
+            (
+                Coord::new(XCoord::B, YCoord::Six),
+                PositionStatus::default(),
+            ),
             // C => 3, 4, 5
-            (Coord::new(XCoord::C, YCoord::Three), (false, None)),
-            (Coord::new(XCoord::C, YCoord::Four), (false, None)),
-            (Coord::new(XCoord::C, YCoord::Five), (false, None)),
+            (
+                Coord::new(XCoord::C, YCoord::Three),
+                PositionStatus::default(),
+            ),
+            (
+                Coord::new(XCoord::C, YCoord::Four),
+                PositionStatus::default(),
+            ),
+            (
+                Coord::new(XCoord::C, YCoord::Five),
+                PositionStatus::default(),
+            ),
             // D => 1, 2, 3, 5, 6, 7
-            (Coord::new(XCoord::D, YCoord::One), (false, None)),
-            (Coord::new(XCoord::D, YCoord::Two), (false, None)),
-            (Coord::new(XCoord::D, YCoord::Three), (false, None)),
-            (Coord::new(XCoord::D, YCoord::Five), (false, None)),
-            (Coord::new(XCoord::D, YCoord::Six), (false, None)),
-            (Coord::new(XCoord::D, YCoord::Seven), (false, None)),
+            (
+                Coord::new(XCoord::D, YCoord::One),
+                PositionStatus::default(),
+            ),
+            (
+                Coord::new(XCoord::D, YCoord::Two),
+                PositionStatus::default(),
+            ),
+            (
+                Coord::new(XCoord::D, YCoord::Three),
+                PositionStatus::default(),
+            ),
+            (
+                Coord::new(XCoord::D, YCoord::Five),
+                PositionStatus::default(),
+            ),
+            (
+                Coord::new(XCoord::D, YCoord::Six),
+                PositionStatus::default(),
+            ),
+            (
+                Coord::new(XCoord::D, YCoord::Seven),
+                PositionStatus::default(),
+            ),
             // E => 3, 4, 5
-            (Coord::new(XCoord::E, YCoord::Three), (false, None)),
-            (Coord::new(XCoord::E, YCoord::Four), (false, None)),
-            (Coord::new(XCoord::E, YCoord::Five), (false, None)),
+            (
+                Coord::new(XCoord::E, YCoord::Three),
+                PositionStatus::default(),
+            ),
+            (
+                Coord::new(XCoord::E, YCoord::Four),
+                PositionStatus::default(),
+            ),
+            (
+                Coord::new(XCoord::E, YCoord::Five),
+                PositionStatus::default(),
+            ),
             // F => 2, 4, 6
-            (Coord::new(XCoord::F, YCoord::Two), (false, None)),
-            (Coord::new(XCoord::F, YCoord::Four), (false, None)),
-            (Coord::new(XCoord::F, YCoord::Six), (false, None)),
+            (
+                Coord::new(XCoord::F, YCoord::Two),
+                PositionStatus::default(),
+            ),
+            (
+                Coord::new(XCoord::F, YCoord::Four),
+                PositionStatus::default(),
+            ),
+            (
+                Coord::new(XCoord::F, YCoord::Six),
+                PositionStatus::default(),
+            ),
             // G => 1, 4, 7
-            (Coord::new(XCoord::G, YCoord::One), (false, None)),
-            (Coord::new(XCoord::G, YCoord::Four), (false, None)),
-            (Coord::new(XCoord::G, YCoord::Seven), (false, None)),
+            (
+                Coord::new(XCoord::G, YCoord::One),
+                PositionStatus::default(),
+            ),
+            (
+                Coord::new(XCoord::G, YCoord::Four),
+                PositionStatus::default(),
+            ),
+            (
+                Coord::new(XCoord::G, YCoord::Seven),
+                PositionStatus::default(),
+            ),
         ]
         .iter()
         .cloned()
@@ -279,6 +351,10 @@ impl Manager {
 
     pub fn poll(act: Action, opts: GameOpts) -> Board {
         unimplemented!()
+    }
+
+    pub fn get_board(self) -> Board {
+        self.state.board.clone()
     }
 }
 

--- a/nmm/native/base/src/lib.rs
+++ b/nmm/native/base/src/lib.rs
@@ -193,6 +193,24 @@ impl Board {
     pub fn new() -> Self {
         Board::default()
     }
+
+    fn add(&mut self, k: Coord, v: PositionStatus) {
+        self.0.insert(k, v);
+    }
+
+    pub fn len(&mut self) -> u32 {
+        self.0.len() as u32
+    }
+}
+
+impl IntoIterator for Board {
+    // on god, i think the trait impl requires the assoc type Item but Hashmap literlaly doesn't
+    // use it because it's a tuple type lol
+    type Item = (Coord, PositionStatus);
+    type IntoIter = ::std::collections::hash_map::IntoIter<Coord, PositionStatus>;
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.into_iter()
+    }
 }
 
 impl Default for Board {

--- a/nmm/native/base/src/lib.rs
+++ b/nmm/native/base/src/lib.rs
@@ -1,6 +1,7 @@
 #![allow(non_snake_case)]
 #![allow(dead_code)]
 
+use std::string::ToString;
 use std::{cell::RefCell, collections::HashMap, rc::Rc};
 use strum_macros::Display;
 
@@ -27,7 +28,7 @@ enum XCoord {
     G,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, PartialOrd, Hash, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, PartialOrd, Hash, Eq, Display)]
 enum YCoord {
     One = 1,
     Two = 2,
@@ -39,7 +40,7 @@ enum YCoord {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, PartialOrd, Hash, Eq)]
-struct Coord(XCoord, YCoord);
+pub struct Coord(XCoord, YCoord);
 
 type Adjacents = Option<Rc<RefCell<Position>>>;
 
@@ -158,6 +159,9 @@ impl Coord {
         } else {
             panic!("Invalid Coordinate: Missing X");
         }
+    }
+    pub fn as_string(self) -> String {
+        format!("{}{}", self.0, self.1 as u32)
     }
 }
 

--- a/nmm/native/base/src/lib.rs
+++ b/nmm/native/base/src/lib.rs
@@ -57,7 +57,8 @@ struct Mill {
     Pieces: (Position, Position, Position),
 }
 
-type PositionStatus = (bool, Option<Player>);
+#[derive(Debug, Clone, Copy)]
+pub struct PositionStatus(bool, Option<Player>);
 
 #[derive(Debug, Clone)]
 pub struct Board(HashMap<Coord, PositionStatus>);
@@ -141,6 +142,29 @@ impl YCoord {
             '7' => YCoord::Seven,
             e => panic!("Invalid YCoord Character: {:?}", e),
         }
+    }
+}
+
+impl PositionStatus {
+    pub fn new() -> Self {
+        PositionStatus::default()
+    }
+    pub fn as_string(self) -> String {
+        if self.0 {
+            if let Some(p) = self.1 {
+                return format!("{}", p);
+            } else {
+                panic!("PositionStatus set to true, but Player is None")
+            }
+        } else {
+            return format!("None");
+        }
+    }
+}
+
+impl Default for PositionStatus {
+    fn default() -> Self {
+        PositionStatus(false, None)
     }
 }
 

--- a/nmm/native/src/lib.rs
+++ b/nmm/native/src/lib.rs
@@ -1,11 +1,44 @@
+use base::{GameState, Manager};
 use neon::prelude::*;
-use neon::register_module;
+use neon::{class_definition, declare_types, impl_managed, register_module};
 
-use base::base_hello;
+declare_types! {
+    pub class JsManager for Manager {
+        init(mut ctx) {
+            Ok(
+                Manager::new()
+            )
+        }
+
+        method get_board(mut ctx) {
+            let this = ctx.this();
+            let mut board = {
+                let guard = ctx.lock();
+                let mngr = this.borrow(&guard);
+                // TODO: more efficient moving of Manager value
+                // have to clone manager because it can't derive clone
+                // due to hashmap. I don't know how to move around this
+                // immediately without just wrapping it in an Rc so the clone
+                // is at least cheaper to perform.
+                mngr.clone().get_board()
+            };
+
+            let js_board_arr = JsArray::new(&mut ctx, board.len());
 
 
-fn hello(mut cx: FunctionContext) -> JsResult<JsString> {
-    Ok(cx.string(base_hello()))
+            for (k, v) in board {
+
+                let str_k = ctx.string(k.as_string());
+                let str_v = ctx.string(v.as_string());
+
+                let _ = js_board_arr.set(&mut ctx, str_k, str_v);
+            }
+            Ok(js_board_arr.as_value(&mut ctx))
+
+        }
+    }
 }
 
-register_module!(mut cx, { cx.export_function("hello", hello) });
+register_module!(mut cx, { cx.export_class::<JsManager>("Manager") });
+
+// register_module!(mut cx, { cx.export_function("hello", hello) });


### PR DESCRIPTION
Given the work done thus far, this is going to be the first of a few PR's necessary to get #24 properly done. For this PR, I only addressed the most basic aspects of exporting `Manager` to Js, and I started that by exposing a method on its Js equivalent that gets you a JsArray representation of `Board`.

So, in other words, `Board`, has been exported to Js, which marks that type as done, and I accomplished that by beginning the process of exporting `Manager` itself to Js.

My [comment](https://github.com/amadeusine/CS449GroupProject/issues/24#issuecomment-548562728) from the issue explains more of the changes in detail for this specific PR.