### PR TITLE
Refactor .poll and Manager API

### DIFF
--- a/nmm/lib/index.js
+++ b/nmm/lib/index.js
@@ -17,13 +17,11 @@ console.log(gameState.trigger);
 console.log("\ngameState.board:\n");
 console.log(gameState.board);
 
-var options = {"user": 1, "opponent": 2, "agent": "human", "position": ["A", "1"]};
-var type = "Piece";
+var options = {"user": 1, "opponent": 2, "agent": "human","position": ["A", "1"], "sender": 1};
 // console.log(man.get_user(options));
 console.log(Manager.prototype);
 console.log(man.get_user(options));
 console.log(man.get_opponent(options));
 console.log(man.get_agent(options));
-console.log(man.get_req_type(type));
 console.log(man.get_position(options));
 // console.log(man.get_opponent(options));

--- a/nmm/lib/tests/exports.js
+++ b/nmm/lib/tests/exports.js
@@ -22,9 +22,8 @@ describe('Neon Exported Objects', function () {
     });
     it('can call NAIVE poll() method defined on Manager in Rust', function() {
         var mngr = new Manager();
-        var options = {"user": 1, "opponent": 2, "agent": "human", "position": ["A", "1"]};
-        var type = "Menu";
-        var result = mngr.poll(type, options);
+        var options = {"position": ["A", "1"], "sender": 1};
+        var result = mngr.poll(options);
         assert.equal(result, 'Ya did it!');
     });
     it('can call the get_board method defined on Manager in Rust', function() {

--- a/nmm/native/base/src/lib.rs
+++ b/nmm/native/base/src/lib.rs
@@ -347,6 +347,15 @@ impl GameState {
 }
 
 impl GameOpts {
+    pub fn new() -> Self {
+        GameOpts {
+            user: None,
+            opponent: None,
+            agent: None,
+            sender: None,
+            position: None,
+        }
+    }
     pub fn new_game_opt(user: u32, opp: u32, agent: Agent) -> Self {
         let user = match user {
             1 => Some(Player::PlayerOne),
@@ -385,12 +394,15 @@ impl GameOpts {
 }
 
 impl Manager {
-    pub fn new(user: u32, opponent: u32, agent: Agent) -> Self {
-        let opts = GameOpts::new_game_opt(user, opponent, agent);
+    pub fn new() -> Self {
         Manager {
             state: GameState::new(),
-            settings: opts,
+            settings: GameOpts::new(),
         }
+    }
+
+    pub fn new_opts(&mut self, game_opts: GameOpts) {
+        self.settings = game_opts;
     }
 
     // poll() will eventually use Action and Opts together to figure out what game logic to compute
@@ -474,7 +486,7 @@ mod base_tests {
         use super::{Agent, Board, Handle, Manager, Trigger};
 
         assert_eq!(
-            Manager::new(1, 2, Agent::Human).poll(),
+            Manager::new().poll(),
             (Handle::Ok, Trigger::None, Board::new())
         );
     }
@@ -482,7 +494,6 @@ mod base_tests {
     #[test]
     fn test_manager_new_get_board() {
         use super::{Agent, Board, Manager};
-
-        assert_eq!(Manager::new(1, 2, Agent::Human).get_board(), Board::new());
+        assert_eq!(Manager::new().get_board(), Board::new());
     }
 }

--- a/nmm/native/base/src/lib.rs
+++ b/nmm/native/base/src/lib.rs
@@ -77,12 +77,6 @@ pub enum Trigger {
     Lose,
 }
 
-#[derive(Debug, Clone, Copy, PartialOrd, PartialEq, Display)]
-pub enum Action {
-    Menu,
-    Piece,
-}
-
 // TODO: Make top level GameResult type that wraps GameState and custom GameErr types?
 #[derive(Debug, Clone, PartialEq)]
 pub struct GameState {
@@ -421,15 +415,6 @@ impl Manager {
 
     pub fn get_board(&self) -> Board {
         self.state.get_board()
-    }
-
-    pub fn get_action(act: &str) -> Action {
-        match act {
-            "Menu" => Action::Menu,
-            "Piece" => Action::Piece,
-            other => panic!("Invalid type passed as ElementType: {:#?}", other),
-        };
-        unimplemented!()
     }
 }
 

--- a/nmm/native/base/src/lib.rs
+++ b/nmm/native/base/src/lib.rs
@@ -104,6 +104,7 @@ pub struct GameOpts {
 #[derive(Debug, Clone, PartialEq)]
 pub struct Manager {
     state: GameState,
+    settings: GameOpts,
 }
 
 impl XCoord {
@@ -346,7 +347,7 @@ impl GameState {
 }
 
 impl GameOpts {
-    pub fn new_menu_opt(user: u32, opp: u32, agent: Agent) -> Self {
+    pub fn new_game_opt(user: u32, opp: u32, agent: Agent) -> Self {
         let user = match user {
             1 => Some(Player::PlayerOne),
             2 => Some(Player::PlayerTwo),
@@ -384,9 +385,11 @@ impl GameOpts {
 }
 
 impl Manager {
-    pub fn new() -> Self {
+    pub fn new(user: u32, opponent: u32, agent: Agent) -> Self {
+        let opts = GameOpts::new_game_opt(user, opponent, agent);
         Manager {
             state: GameState::new(),
+            settings: opts,
         }
     }
 
@@ -468,18 +471,18 @@ mod base_tests {
 
     #[test]
     fn test_manager_new_get_curr_state() {
-        use super::{Board, Handle, Manager, Trigger};
+        use super::{Agent, Board, Handle, Manager, Trigger};
 
         assert_eq!(
-            Manager::new().poll(),
+            Manager::new(1, 2, Agent::Human).poll(),
             (Handle::Ok, Trigger::None, Board::new())
         );
     }
 
     #[test]
     fn test_manager_new_get_board() {
-        use super::{Board, Manager};
+        use super::{Agent, Board, Manager};
 
-        assert_eq!(Manager::new().get_board(), Board::new());
+        assert_eq!(Manager::new(1, 2, Agent::Human).get_board(), Board::new());
     }
 }

--- a/nmm/native/src/lib.rs
+++ b/nmm/native/src/lib.rs
@@ -19,9 +19,21 @@ fn conv_new_game_opts(ctx: &mut MethodContext<JsManager>, opts: &mut JsObject) -
 declare_types! {
     pub class JsManager for Manager {
         init(mut ctx) {
-            Ok(
-                Manager::new()
-            )
+            Ok(Manager::new())
+        }
+
+        method new(mut ctx) {
+            let mut opts = ctx.argument::<JsObject>(0)?;
+            let game_opts = conv_new_game_opts(&mut ctx, &mut opts);
+            let mut this = ctx.this();
+            let _ = {
+                let guard = ctx.lock();
+                let mut mngr = this.borrow_mut(&guard);
+                mngr.new_opts(game_opts)
+            };
+
+            Ok(ctx.string("undefined").upcast())
+
         }
 
         method get_board(mut ctx) {

--- a/nmm/native/src/lib.rs
+++ b/nmm/native/src/lib.rs
@@ -8,6 +8,12 @@ fn conv_poll_opts(ctx: &mut MethodContext<JsManager>, opts: &mut JsObject) -> Ga
         conv_position_option(ctx, opts),
     )
 }
+fn conv_new_game_opts(ctx: &mut MethodContext<JsManager>, opts: &mut JsObject) -> GameOpts {
+    GameOpts::new_game_opt(
+        conv_player_option(ctx, opts, "user"),
+        conv_player_option(ctx, opts, "opponent"),
+        conv_agent_option(ctx, opts),
+    )
 }
 
 declare_types! {


### PR DESCRIPTION
This PR implements the design change described in #43. The pushed changes already remove the `Action` type from the base subcrate, removes all deprecated code, and refactors what remains to compile and run.

What remains now is to restructure the constructor of `Manager` to appropriately handle the information passed by the `options` value that typically went along with a `Menu` game action.